### PR TITLE
Mobility GHC-9.2.5 work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,6 @@ Do not use it for projects other than Mobilty yet, since it uses upstream Beam.
 
 Main changes : -
 
-* Upgrade to stackage lts-20.4 from lts-15.15
+* Upgrade to stackage lts-20.11 from lts-15.15
 * Upgrade to Aeson 2 & Migrate to Aeson 2 with is KeyMap syntax.
 * Upgrade to & use upstream Beam instead of internal Forks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## version 1.2.0.0
+
+This is a Upgrade w.r.t to the larger upgrade process for the Mobilty set of projects.
+
+This is a dependency for Euler-hs, which is in-turn, a dependency for Mobilty set of projects, thus this needs to be upgraded to newest GHC.
+
+Do not use it for projects other than Mobilty yet, since it uses upstream Beam.
+
+Main changes : -
+
+* Upgrade to stackage lts-20.4 from lts-15.15
+* Upgrade to Aeson 2 & Migrate to Aeson 2 with is KeyMap syntax.
+* Upgrade to & use upstream Beam instead of internal Forks

--- a/sequelize.cabal
+++ b/sequelize.cabal
@@ -7,7 +7,7 @@ cabal-version: 2.0
 -- hash: 492410794b7d56b74a2a0cc2cb2d4ea37d2c1711251fc612e511aab5adfc35e6
 
 name:           sequelize
-version:        1.1.1.0
+version:        1.2.0.0
 description:    A port of <https://github.com/juspay/purescript-sequelize> into Haskell
 author:         Artyom Kazak
 maintainer:     artyom.kazak@juspay.in
@@ -28,12 +28,12 @@ library
   default-extensions: AllowAmbiguousTypes RankNTypes ScopedTypeVariables StandaloneDeriving EmptyDataDecls FlexibleContexts FlexibleInstances FunctionalDependencies KindSignatures TypeOperators MultiParamTypeClasses TypeFamilies OverloadedLabels OverloadedStrings DeriveFunctor DeriveGeneric DataKinds DerivingStrategies ConstraintKinds UndecidableInstances InstanceSigs BlockArguments LambdaCase EmptyDataDeriving TypeOperators ViewPatterns KindSignatures
   ghc-options: -Wall
   build-depends:
-      aeson
-    , base >=4.7 && <5
-    , beam-core             ^>=0.9.0.0
-    , beam-mysql            ^>=1.3.0.4
-    , beam-postgres         ^>=0.5.0.0
-    , beam-sqlite           ^>=0.5.0.0
+      aeson                  >=2.0.1.0
+    , base                   >=4.7 && <5
+    , beam-core
+    , beam-mysql
+    , beam-postgres
+    , beam-sqlite
     , bytestring
     , containers
     , generic-lens
@@ -53,12 +53,12 @@ test-suite sequelize-test
   default-extensions: AllowAmbiguousTypes RankNTypes ScopedTypeVariables StandaloneDeriving EmptyDataDecls FlexibleContexts FlexibleInstances FunctionalDependencies KindSignatures TypeOperators MultiParamTypeClasses TypeFamilies OverloadedLabels OverloadedStrings DeriveFunctor DeriveGeneric DataKinds DerivingStrategies ConstraintKinds UndecidableInstances InstanceSigs BlockArguments LambdaCase EmptyDataDeriving TypeOperators ViewPatterns KindSignatures
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson
-    , base >=4.7 && <5
-    , beam-core             ^>=0.9.0.0
-    , beam-mysql            ^>=1.3.0.4
-    , beam-postgres         ^>=0.5.0.0
-    , beam-sqlite           ^>=0.5.0.0
+      aeson                  >=2.0.1.0
+    , base                   >=4.7 && <5
+    , beam-core
+    , beam-mysql
+    , beam-postgres
+    , beam-sqlite
     , bytestring
     , containers
     , generic-lens

--- a/src/Sequelize.hs
+++ b/src/Sequelize.hs
@@ -349,8 +349,8 @@ applyOrderBy mbOrderBy_ x = case mbOrderBy_ of
 applyWhere ::
   (B.BeamSqlBackend be, B.Beamable table) =>
   Maybe (Where be table) ->
-  (forall s. B.Q be db s (table (B.QExpr be s))) ->
-  (forall s. B.Q be db s (table (B.QExpr be s)))
+  (B.Q be db s (table (B.QExpr be s))) ->
+  (B.Q be db s (table (B.QExpr be s)))
 applyWhere mbWhere_ = maybe id (B.filter_' . whereQ) mbWhere_
 
 ----------------------------------------------------------------------------

--- a/src/Sequelize/Encode.hs
+++ b/src/Sequelize/Encode.hs
@@ -8,7 +8,8 @@ module Sequelize.Encode
 where
 
 import qualified Data.Aeson as Aeson
-import qualified Data.HashMap.Strict as HM
+import qualified Data.Aeson.KeyMap as AKM
+import qualified Data.Aeson.Key as AesonKey (fromText)
 import Data.Kind ()
 import Data.Text (Text)
 import qualified Database.Beam as B
@@ -43,21 +44,21 @@ encodeClause dt w =
         Or cs -> foldOr cs
         Is column val -> foldIs column val
       foldAnd = \case
-        [] -> HM.empty
+        [] -> AKM.empty
         [x] -> foldWhere' x
         xs
           | Just maps <- mapM fromIs xs -> mconcat maps
-          | otherwise -> HM.singleton "$and" (Aeson.toJSON $ map foldWhere' xs)
+          | otherwise -> AKM.singleton "$and" (Aeson.toJSON $ map foldWhere' xs)
       foldOr = \case
-        [] -> HM.empty
+        [] -> AKM.empty
         [x] -> foldWhere' x
-        xs -> HM.singleton "$or" (Aeson.toJSON $ map foldWhere' xs)
+        xs -> AKM.singleton "$or" (Aeson.toJSON $ map foldWhere' xs)
       foldIs :: Aeson.ToJSON a => Column table value -> Term be a -> Aeson.Object
       foldIs column val =
         let key =
               B._fieldName . fromColumnar' . column . columnize $
                 B.dbTableSettings dt
-         in HM.singleton key $ encodeTerm val
+         in AKM.singleton (AesonKey.fromText key) $ encodeTerm val
       fromIs :: Clause be table -> Maybe Aeson.Object
       fromIs = \case
         Is column val -> Just (foldIs column val)
@@ -97,7 +98,7 @@ encodeTerm = \case
   Not term -> single encodeTerm "$not" term
 
 array :: (a -> Aeson.Value) -> Text -> [a] -> Aeson.Value
-array f k vs = Aeson.toJSON $ HM.singleton k $ map f vs
+array f k vs = Aeson.toJSON $ AKM.singleton (AesonKey.fromText k) $ map f vs
 
 single :: (a -> Aeson.Value) -> Text -> a -> Aeson.Value
-single f k v = Aeson.toJSON $ HM.singleton k $ f v
+single f k v = Aeson.toJSON $ AKM.singleton (AesonKey.fromText k) $ f v

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,8 +16,8 @@ extra-deps:
   - git: https://github.com/winterland1989/word24.git
     commit: 445f791e35ddc8098f05879dbcd07c41b115cb39
 
-  - git: https://github.com/arjunkathuria/beam-mysql
-    commit: da39c9bc7f4597bc40c3838ed7f2c9f073d25ad8
+  - git: https://github.com/juspay/beam-mysql
+    commit: f8d029e6861ade3335a9f96b7be3b306d8208dd8
 
   # # Needed for beam-mysql
   - int-cast-0.2.0.0@sha256:06820c1c5335100c5021e01314cd498e4d248582622c36d8e7203fa4341cb6d0,1668

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,27 +12,7 @@ packages:
 - .
 
 extra-deps:
-  - ../beam/beam-core
-  - ../beam/beam-migrate
-  - ../beam/beam-sqlite
-  - ../beam/beam-postgres
-  - ../beam-mysql
-
-  - named-0.3.0.1@sha256:2975d50c9c5d88095026ffc1303d2d9be52e5f588a8f8bcb7003a04b79f10a06,2312
-  # Needed for beam
-  - dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
-  - dependent-sum-0.7.1.0@sha256:5599aa89637db434431b1dd3fa7c34bc3d565ee44f0519bfbc877be1927c2531,2068
-  - haskell-src-exts-1.21.1@sha256:11d18ec3f463185f81b7819376b532e3087f8192cffc629aac5c9eec88897b35,4541
-  - sqlite-simple-0.4.18.0@sha256:3ceea56375c0a3590c814e411a4eb86943f8d31b93b110ca159c90689b6b39e5,3002
-  - constraints-extras-0.3.0.2@sha256:bf6884be65958e9188ae3c9e5547abfd6d201df021bff8a4704c2c4fe1e1ae5b,1784
-  - direct-sqlite-2.3.26@sha256:04e835402f1508abca383182023e4e2b9b86297b8533afbd4e57d1a5652e0c23,3718
-  # Needed for compatibility with euler-hs
-  - generic-lens-1.1.0.0
-  - mason-0.2.4@sha256:9de93b2f429fee78f758bd11bea7e183756567bfae4acef369405733bb0538be,1226
-  - mysql-haskell-0.8.4.3@sha256:d3ca21ae8cc88670f8adb17c7cacb8bb770f1a58d60b5bff346d1f3fc843d98c,3489
-  - record-dot-preprocessor-0.2.13@sha256:8eb71fdeb5286c71d5c4b0e7768ad14e19a79ae8a102c65c649b64419678332b,2538
-  - tcp-streams-1.0.1.1@sha256:35e9ecfa515797052f8c3c01834d2daebd5e93f3152c7fc98b32652bf6f0c052,2329
-  - wire-streams-0.1.1.0@sha256:08816c7fa53b20f52e5c465252c106d9de8e6d9580ec0b6d9f000a34c7bcefc8,2130
+  - beam-mysql-0.2.0.0@sha256:6c64358de5094463a70e8c71dbc99a38ae937d04a44cee9858e8a0779bb7b8dd,2282
 
 extra-include-dirs:
   - /usr/local/opt/openssl/include

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,18 @@ packages:
 - .
 
 extra-deps:
-  - beam-mysql-0.2.0.0@sha256:6c64358de5094463a70e8c71dbc99a38ae937d04a44cee9858e8a0779bb7b8dd,2282
+
+  - git: https://github.com/winterland1989/word24.git
+    commit: 445f791e35ddc8098f05879dbcd07c41b115cb39
+
+  - git: https://github.com/arjunkathuria/beam-mysql
+    commit: da39c9bc7f4597bc40c3838ed7f2c9f073d25ad8
+
+  # # Needed for beam-mysql
+  - int-cast-0.2.0.0@sha256:06820c1c5335100c5021e01314cd498e4d248582622c36d8e7203fa4341cb6d0,1668
+  - mysql-haskell-0.8.4.3@sha256:d3ca21ae8cc88670f8adb17c7cacb8bb770f1a58d60b5bff346d1f3fc843d98c,3489
+  - binary-parsers-0.2.4.0@sha256:8c3a436df2d721cb3268c3c56f9ce982bc5dbcd6e6db4cce24e96d1d48078678,3595
+  - wire-streams-0.1.1.0@sha256:08816c7fa53b20f52e5c465252c106d9de8e6d9580ec0b6d9f000a34c7bcefc8,2130
 
 extra-include-dirs:
   - /usr/local/opt/openssl/include

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.4
+resolver: lts-20.11
 system-ghc: true
 allow-newer: true
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,6 @@
-resolver: lts-15.15
+resolver: lts-20.4
+system-ghc: true
+allow-newer: true
 
 # NixOS support.
 # Disabled by default; use as `stack run --nix` or `stack build --nix`.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,55 @@
 
 packages:
 - completed:
-    hackage: beam-mysql-0.2.0.0@sha256:6c64358de5094463a70e8c71dbc99a38ae937d04a44cee9858e8a0779bb7b8dd,2282
+    commit: 445f791e35ddc8098f05879dbcd07c41b115cb39
+    git: https://github.com/winterland1989/word24.git
+    name: word24
     pantry-tree:
-      sha256: ed62694a4bf6afc18ab12dd7227d3aa64a575f387efe3b35fe95b1f3ce71a940
-      size: 389
+      sha256: e15be9bd109d3bf4f603b811a92b04776231473de10cbb69aed8e9e5827698f9
+      size: 758
+    version: 2.0.1
   original:
-    hackage: beam-mysql-0.2.0.0@sha256:6c64358de5094463a70e8c71dbc99a38ae937d04a44cee9858e8a0779bb7b8dd,2282
+    commit: 445f791e35ddc8098f05879dbcd07c41b115cb39
+    git: https://github.com/winterland1989/word24.git
+- completed:
+    commit: da39c9bc7f4597bc40c3838ed7f2c9f073d25ad8
+    git: https://github.com/arjunkathuria/beam-mysql
+    name: beam-mysql
+    pantry-tree:
+      sha256: be45d078ad1f7669ea06b63b585f95527abd6889199be047781ab25cbb959403
+      size: 4305
+    version: 1.3.0.4
+  original:
+    commit: da39c9bc7f4597bc40c3838ed7f2c9f073d25ad8
+    git: https://github.com/arjunkathuria/beam-mysql
+- completed:
+    hackage: int-cast-0.2.0.0@sha256:06820c1c5335100c5021e01314cd498e4d248582622c36d8e7203fa4341cb6d0,1668
+    pantry-tree:
+      sha256: 14ac1ac61570594503174ad96e61168e55fa3f562975c028afd854656bac11d9
+      size: 316
+  original:
+    hackage: int-cast-0.2.0.0@sha256:06820c1c5335100c5021e01314cd498e4d248582622c36d8e7203fa4341cb6d0,1668
+- completed:
+    hackage: mysql-haskell-0.8.4.3@sha256:d3ca21ae8cc88670f8adb17c7cacb8bb770f1a58d60b5bff346d1f3fc843d98c,3489
+    pantry-tree:
+      sha256: c974f4d4f24bb7e17d633301a442a0a5162d30e163cad618a961d61192b6debc
+      size: 1754
+  original:
+    hackage: mysql-haskell-0.8.4.3@sha256:d3ca21ae8cc88670f8adb17c7cacb8bb770f1a58d60b5bff346d1f3fc843d98c,3489
+- completed:
+    hackage: binary-parsers-0.2.4.0@sha256:8c3a436df2d721cb3268c3c56f9ce982bc5dbcd6e6db4cce24e96d1d48078678,3595
+    pantry-tree:
+      sha256: fc345d67d2cb2a08beb45626bd9d26eb294849eba7632068b270528ea788217a
+      size: 3556
+  original:
+    hackage: binary-parsers-0.2.4.0@sha256:8c3a436df2d721cb3268c3c56f9ce982bc5dbcd6e6db4cce24e96d1d48078678,3595
+- completed:
+    hackage: wire-streams-0.1.1.0@sha256:08816c7fa53b20f52e5c465252c106d9de8e6d9580ec0b6d9f000a34c7bcefc8,2130
+    pantry-tree:
+      sha256: c99a12bfcbeacc5da8f166fbed1eb105a45f08be1a3a071fe9f903b386b14e1d
+      size: 506
+  original:
+    hackage: wire-streams-0.1.1.0@sha256:08816c7fa53b20f52e5c465252c106d9de8e6d9580ec0b6d9f000a34c7bcefc8,2130
 snapshots:
 - completed:
     sha256: 3770dfd79f5aed67acdcc65c4e7730adddffe6dba79ea723cfb0918356fc0f94

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,99 +5,15 @@
 
 packages:
 - completed:
-    hackage: named-0.3.0.1@sha256:2975d50c9c5d88095026ffc1303d2d9be52e5f588a8f8bcb7003a04b79f10a06,2312
+    hackage: beam-mysql-0.2.0.0@sha256:6c64358de5094463a70e8c71dbc99a38ae937d04a44cee9858e8a0779bb7b8dd,2282
     pantry-tree:
-      size: 426
-      sha256: e0df5f146ecd48ef129dd74f868e8d2d754f0a11b36c5d0e56bd4b1947433c9f
+      sha256: ed62694a4bf6afc18ab12dd7227d3aa64a575f387efe3b35fe95b1f3ce71a940
+      size: 389
   original:
-    hackage: named-0.3.0.1@sha256:2975d50c9c5d88095026ffc1303d2d9be52e5f588a8f8bcb7003a04b79f10a06,2312
-- completed:
-    hackage: dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
-    pantry-tree:
-      size: 551
-      sha256: 5defa30010904d2ad05a036f3eaf83793506717c93cbeb599f40db1a3632cfc5
-  original:
-    hackage: dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
-- completed:
-    hackage: dependent-sum-0.7.1.0@sha256:5599aa89637db434431b1dd3fa7c34bc3d565ee44f0519bfbc877be1927c2531,2068
-    pantry-tree:
-      size: 290
-      sha256: 9cbfb32b5a8a782b7a1c941803fd517633cb699159b851c1d82267a9e9391b50
-  original:
-    hackage: dependent-sum-0.7.1.0@sha256:5599aa89637db434431b1dd3fa7c34bc3d565ee44f0519bfbc877be1927c2531,2068
-- completed:
-    hackage: haskell-src-exts-1.21.1@sha256:11d18ec3f463185f81b7819376b532e3087f8192cffc629aac5c9eec88897b35,4541
-    pantry-tree:
-      size: 95170
-      sha256: 487db8defe20a7c8bdf5b4a9a68ec616a4349bdb643f2dc7c9d71e1a6495c8c7
-  original:
-    hackage: haskell-src-exts-1.21.1@sha256:11d18ec3f463185f81b7819376b532e3087f8192cffc629aac5c9eec88897b35,4541
-- completed:
-    hackage: sqlite-simple-0.4.18.0@sha256:3ceea56375c0a3590c814e411a4eb86943f8d31b93b110ca159c90689b6b39e5,3002
-    pantry-tree:
-      size: 1930
-      sha256: e58b9955e483d51ee0966f8ba4384305d871480e2a38b32ee0fcd4573d74cf95
-  original:
-    hackage: sqlite-simple-0.4.18.0@sha256:3ceea56375c0a3590c814e411a4eb86943f8d31b93b110ca159c90689b6b39e5,3002
-- completed:
-    hackage: constraints-extras-0.3.0.2@sha256:bf6884be65958e9188ae3c9e5547abfd6d201df021bff8a4704c2c4fe1e1ae5b,1784
-    pantry-tree:
-      size: 594
-      sha256: b0bcc96d375ee11b1972a2e9e8e42039b3f420b0e1c46e9c70652470445a6505
-  original:
-    hackage: constraints-extras-0.3.0.2@sha256:bf6884be65958e9188ae3c9e5547abfd6d201df021bff8a4704c2c4fe1e1ae5b,1784
-- completed:
-    hackage: direct-sqlite-2.3.26@sha256:04e835402f1508abca383182023e4e2b9b86297b8533afbd4e57d1a5652e0c23,3718
-    pantry-tree:
-      size: 770
-      sha256: 11874ab21e10c5b54cd1e02a037b677dc1e2ee9986f38c599612c56654dc01c3
-  original:
-    hackage: direct-sqlite-2.3.26@sha256:04e835402f1508abca383182023e4e2b9b86297b8533afbd4e57d1a5652e0c23,3718
-- completed:
-    hackage: generic-lens-1.1.0.0@sha256:caaab13ae4f2a68e43671d25fb56746ba14bc9d5d787d594a66c7f56eba3fa66,6412
-    pantry-tree:
-      size: 4174
-      sha256: 33e1509b7d786d816a0974f08cfb6208a7d02c7d45937bec2c91586523b14440
-  original:
-    hackage: generic-lens-1.1.0.0
-- completed:
-    hackage: mason-0.2.4@sha256:9de93b2f429fee78f758bd11bea7e183756567bfae4acef369405733bb0538be,1226
-    pantry-tree:
-      size: 574
-      sha256: 52308ea42ca423d9f243d31a7d1f88515ccb8497d1bc07f857beb4b0428613f5
-  original:
-    hackage: mason-0.2.4@sha256:9de93b2f429fee78f758bd11bea7e183756567bfae4acef369405733bb0538be,1226
-- completed:
-    hackage: mysql-haskell-0.8.4.3@sha256:d3ca21ae8cc88670f8adb17c7cacb8bb770f1a58d60b5bff346d1f3fc843d98c,3489
-    pantry-tree:
-      size: 1754
-      sha256: c974f4d4f24bb7e17d633301a442a0a5162d30e163cad618a961d61192b6debc
-  original:
-    hackage: mysql-haskell-0.8.4.3@sha256:d3ca21ae8cc88670f8adb17c7cacb8bb770f1a58d60b5bff346d1f3fc843d98c,3489
-- completed:
-    hackage: record-dot-preprocessor-0.2.13@sha256:8eb71fdeb5286c71d5c4b0e7768ad14e19a79ae8a102c65c649b64419678332b,2538
-    pantry-tree:
-      size: 1078
-      sha256: d975de7bc84e142449273228bbfab0d8958e8a3503e7386bc1cd23417e301aba
-  original:
-    hackage: record-dot-preprocessor-0.2.13@sha256:8eb71fdeb5286c71d5c4b0e7768ad14e19a79ae8a102c65c649b64419678332b,2538
-- completed:
-    hackage: tcp-streams-1.0.1.1@sha256:35e9ecfa515797052f8c3c01834d2daebd5e93f3152c7fc98b32652bf6f0c052,2329
-    pantry-tree:
-      size: 1004
-      sha256: 572071fca40a0b6c4cc950d10277a6f12e83cf4846882b6ef83fcccaa2c18c45
-  original:
-    hackage: tcp-streams-1.0.1.1@sha256:35e9ecfa515797052f8c3c01834d2daebd5e93f3152c7fc98b32652bf6f0c052,2329
-- completed:
-    hackage: wire-streams-0.1.1.0@sha256:08816c7fa53b20f52e5c465252c106d9de8e6d9580ec0b6d9f000a34c7bcefc8,2130
-    pantry-tree:
-      size: 506
-      sha256: c99a12bfcbeacc5da8f166fbed1eb105a45f08be1a3a071fe9f903b386b14e1d
-  original:
-    hackage: wire-streams-0.1.1.0@sha256:08816c7fa53b20f52e5c465252c106d9de8e6d9580ec0b6d9f000a34c7bcefc8,2130
+    hackage: beam-mysql-0.2.0.0@sha256:6c64358de5094463a70e8c71dbc99a38ae937d04a44cee9858e8a0779bb7b8dd,2282
 snapshots:
 - completed:
-    size: 496112
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/15.yaml
-    sha256: 86169722ad0056ffc9eacc157ef80ee21d7024f92c0d2961c89ccf432db230a3
-  original: lts-15.15
+    sha256: 3770dfd79f5aed67acdcc65c4e7730adddffe6dba79ea723cfb0918356fc0f94
+    size: 648660
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/4.yaml
+  original: lts-20.4

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -16,16 +16,16 @@ packages:
     commit: 445f791e35ddc8098f05879dbcd07c41b115cb39
     git: https://github.com/winterland1989/word24.git
 - completed:
-    commit: da39c9bc7f4597bc40c3838ed7f2c9f073d25ad8
-    git: https://github.com/arjunkathuria/beam-mysql
+    commit: f8d029e6861ade3335a9f96b7be3b306d8208dd8
+    git: https://github.com/juspay/beam-mysql
     name: beam-mysql
     pantry-tree:
-      sha256: be45d078ad1f7669ea06b63b585f95527abd6889199be047781ab25cbb959403
+      sha256: 5a2c05b47c6201bc456b052aa90a8cb5f8f6820510700ee48ef13ee4f3be4e87
       size: 4305
     version: 1.3.0.4
   original:
-    commit: da39c9bc7f4597bc40c3838ed7f2c9f073d25ad8
-    git: https://github.com/arjunkathuria/beam-mysql
+    commit: f8d029e6861ade3335a9f96b7be3b306d8208dd8
+    git: https://github.com/juspay/beam-mysql
 - completed:
     hackage: int-cast-0.2.0.0@sha256:06820c1c5335100c5021e01314cd498e4d248582622c36d8e7203fa4341cb6d0,1668
     pantry-tree:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -56,7 +56,7 @@ packages:
     hackage: wire-streams-0.1.1.0@sha256:08816c7fa53b20f52e5c465252c106d9de8e6d9580ec0b6d9f000a34c7bcefc8,2130
 snapshots:
 - completed:
-    sha256: 3770dfd79f5aed67acdcc65c4e7730adddffe6dba79ea723cfb0918356fc0f94
-    size: 648660
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/4.yaml
-  original: lts-20.4
+    sha256: adbc602422dde10cc330175da7de8609e70afc41449a7e2d6e8b1827aa0e5008
+    size: 649342
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/11.yaml
+  original: lts-20.11

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -11,7 +11,7 @@ import Named ((!), defaults)
 import Sequelize
 import Test.Tasty
 import Test.Tasty.HUnit
-import Database.Beam.MySQL.Extra
+import Database.Beam.MySQL
 
 
 ----------------------------------------------------------------------------


### PR DESCRIPTION
`haskell-sequelize` is a dependency of the Mobility project. As a part of the larger upgrade efforts to bring the Mobility set of projects on the newer GHC `9.2.5` platform, this repo needed to be upgraded, in order for it to build with GHC `9.2.5`.

This PR makes changes that enables it to jump from `lts-15.15` with older GHC `8.8.4` to being able to build with newer stackage `lts-20.11` with new GHC `9.2.5`

Apart from being used as a dependency in Mobility set of projects, it is also used in quite a lot of other places, probably because it's a dependency of the fundamental `Euler-hs` framework. As a result, it was imperative that we upgraded this repo and make it build-able with new GHC 9.2.5

**Note**:- Please note that this PR should be merged in a separate `Mobility/GHC-9.2.5` branch which should run as it's own thing for now in parallel. It should **NOT** be merged back in master for now. This version makes use of upstream `Beam` instead of our internal (and outdated) `Beam` forks.